### PR TITLE
fix comment deletion authorization by using User repository for employee lookup

### DIFF
--- a/src/main/java/management/member/demo/service/CommentService.java
+++ b/src/main/java/management/member/demo/service/CommentService.java
@@ -109,6 +109,9 @@ public class CommentService {
         return commentMapper.toResponse(updatedComment);
     }
 
+    @Autowired
+    private management.member.demo.repository.UserRepository userRepository;
+
     /**
      * Xóa comment
      * Chỉ nhân viên đã tạo comment mới có quyền xóa
@@ -118,11 +121,15 @@ public class CommentService {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new ResourceNotFoundException("Comment không tồn tại với ID: " + commentId));
 
-        // 2. Lấy thông tin nhân viên hiện tại
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String currentEmail = authentication.getName();
-        Employee currentEmployee = employeeRepository.findByEmail(currentEmail)
-                .orElseThrow(() -> new ResourceNotFoundException(ErrorCode.EMPLOYEE_NOT_FOUND.getMessage()));
+        // 2. Lấy thông tin nhân viên hiện tại qua User (tránh lỗi email khác nhau)
+        String currentEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+        Employee currentEmployee = userRepository.findByEmail(currentEmail)
+                .map(user -> user.getEmployee())
+                .orElseThrow(() -> new ResourceNotFoundException("Không tìm thấy User với email: " + currentEmail));
+
+        if (currentEmployee == null) {
+            throw new ResourceNotFoundException("User chưa được liên kết với Employee");
+        }
 
         // 3. Kiểm tra quyền: chỉ author mới được xóa
         if (comment.getAuthor() == null || !comment.getAuthor().getId().equals(currentEmployee.getId())) {


### PR DESCRIPTION
## **CodeAnt-AI Description**
Fix comment deletion authorization by resolving employee via User repository

### What Changed
- When deleting a comment, the current user is resolved through the User record to obtain its linked Employee, avoiding mismatches when emails differ between user and employee records.
- If the User is missing or not linked to an Employee, deletion now fails with a clear "User not linked to Employee" error instead of proceeding or failing with a generic not-found.
- The rule that only the comment's author can delete it is preserved; authorization still rejects non-authors.

### Impact
`✅ Correct comment deletion authorization when emails differ`
`✅ Clearer error when a user has no linked employee`
`✅ Fewer accidental authorization failures due to email mismatch`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
